### PR TITLE
Update Chinese Language localization

### DIFF
--- a/promo/_locales/zh-CN/messages.json
+++ b/promo/_locales/zh-CN/messages.json
@@ -9,7 +9,7 @@
     "message": "👌简单易用 🛡️隐私友好"
   },
   "promo_banner_defining_html": {
-    "message": "<span>二维码<br><strong>生成器</strong> 和 <strong>扫描器</strong>"
+    "message": "<span>离线二维码<br><strong>读写器</strong>"
   },
   "promo_screenshot_generator_title_html": {
     "message": "生成<br>二维码"
@@ -33,6 +33,6 @@
     "message": "QR Lite"
   },
   "extension_name": {
-    "message": "QR Lite - 二维码生成器和扫描器"
+    "message": "QR Lite - 离线二维码读写器"
   }
 }

--- a/promo/_locales/zh-TW/messages.json
+++ b/promo/_locales/zh-TW/messages.json
@@ -1,24 +1,24 @@
 {
   "amo_summary": {
-    "message": "👌簡單易用，🛡️注重隱私的QR碼產生與掃描工具。"
+    "message": "👌簡單易用，🛡️注重隱私的 QR 碼產生與掃描工具。"
   },
   "amo_description": {
-    "message": "QR Lite 是一個完全本地運作的二維碼產生器和掃描器。\n\n\n=== 功能 ===\n\n✅ 為以下內容產生二維碼：\n-  目前網頁 \n-  任意連結 \n-  選取的文字 \n-  使用者輸入的文字 \n\n✅ 從下列地方掃描二維碼：\n-  任一圖片 \n-  剪貼簿 \n-  網頁上的任意區域 \n-  網路攝影機 \n\n✅ 記錄產生和掃描的歷史。\n✅ 所有功能完全本地運作，無需聯網。\n\n\nQR Lite 是以 MIT 授權分發的開源軟體。\n如果您喜歡本擴展，請給我們打個5星好評，謝謝 :)"
+    "message": "QR Lite 是一個完全本地運作的 QR Code 產生器和掃描器。\n\n\n=== 功能 ===\n\n✅ 為以下內容產生 QR Code：\n-  目前網頁 \n-  任意連結 \n-  選取的文字 \n-  使用者輸入的文字 \n\n✅ 從下列地方掃描 QR Code：\n-  任一圖片 \n-  剪貼簿 \n-  網頁上的任意區域 \n-  網路攝影機 \n\n✅ 記錄產生和掃描的歷史。\n✅ 所有功能完全本地運作，無需聯網。\n\n\nQR Lite 是以 MIT 授權分發的開源軟體。\n如果您喜歡本擴展，請給我們打個5星好評，謝謝 :)"
   },
   "promo_banner_modifying_html": {
     "message": "👌簡單易用 🛡️隱私友好"
   },
   "promo_banner_defining_html": {
-    "message": "<span>二維碼<br><strong>產生器</strong> 和 <strong>掃描器</strong>"
+    "message": "<span>QR Code<br><strong>產生器</strong> 與 <strong>掃描器</strong>"
   },
   "promo_screenshot_generator_title_html": {
-    "message": "產生<br>二維碼"
+    "message": "產生<br>QR Code"
   },
   "promo_screenshot_generator_description_html": {
     "message": "从分頁，連結，文字皆可"
   },
   "promo_screenshot_scanner_title_html": {
-    "message": "掃描<br>二維碼"
+    "message": "掃描<br>QR Code"
   },
   "promo_screenshot_scanner_description_html": {
     "message": "無論是圖片，剪貼簿，網路攝影機，<br>抑或網頁任意區域"

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -151,7 +151,7 @@
     "message": "退出选区"
   },
   "scan_region_picker_tips_rescan": {
-    "message": "重新扫描"
+    "message": "重新选区"
   },
   "scan_region_picker_tips_open_url_mode_title": {
     "message": "选择如何处理在扫描结果中的网址"
@@ -199,10 +199,10 @@
     "message": "从摄像头扫码"
   },
   "rescan_btn_label": {
-    "message": "重新扫描"
+    "message": "重新选区"
   },
   "rescan_btn_title": {
-    "message": "开始新的扫描"
+    "message": "截取一块新的区域并重新扫描"
   },
   "grant_permissions_instructions_html": {
     "message": "此功能需要以下附加权限。<br><br><strong>$PERMISSION$</strong><br>",

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -1,6 +1,6 @@
 {
   "extension_name": {
-    "message": "QR Lite - 二维码生成器和扫描器"
+    "message": "QR Lite - 离线二维码读写器"
   },
   "extension_short_name": {
     "message": "QR Lite",
@@ -13,13 +13,13 @@
     "message": "保存"
   },
   "save_image_btn_title": {
-    "message": "保存这张二维码图片"
+    "message": "保存这张二维码"
   },
   "copy_image_btn": {
     "message": "复制"
   },
   "copy_image_btn_title": {
-    "message": "复制这张二维码图片到剪贴板"
+    "message": "复制这张二维码到剪贴板"
   },
   "copy_image_ok": {
     "message": "已复制！"
@@ -45,80 +45,95 @@
   "clear_history_btn_title": {
     "message": "清除历史记录"
   },
+  "disable_history_btn_title": {
+    "message": "停止记录扫描或生成的内容"
+  },
+  "disable_history_btn_label": {
+    "message": "停用"
+  },
+  "enable_history_btn_title": {
+    "message": "重新启用历史记录功能"
+  },
+  "enable_history_btn_label": {
+    "message": "启用"
+  },
+  "remove_history_btn_title": {
+    "message": "从历史记录中删除此项"
+  },
   "github_link_title": {
     "message": "访问 QR Lite 在 Github 上的项目主页"
   },
   "toggle_generator_options_btn_label": {
-    "message": "选项"
+    "message": "生成选项"
   },
   "toggle_generator_options_btn_title": {
-    "message": "显示/隐藏二维码生成器选项"
+    "message": "显示/隐藏生成器选项"
   },
   "error_correction_level_btn_low_title": {
-    "message": "低，可以恢复 7% 左右的数据"
+    "message": "低，可修正 7% 的错误字码"
   },
   "error_correction_level_btn_medium_title": {
-    "message": "中，可以恢复 15% 左右的数据"
+    "message": "中，可修正 15% 的错误字码"
   },
   "error_correction_level_btn_quartile_title": {
-    "message": "四分级，可以恢复 25% 左右的数据"
+    "message": "良，可修正 25% 的错误字码"
   },
   "error_correction_level_btn_high_title": {
-    "message": "高，可以恢复 30% 左右的数据"
+    "message": "高，可修正 30% 的错误字码"
   },
   "error_correction_level_label": {
-    "message": "纠错:"
+    "message": "纠错级别："
   },
   "error_correction_level_label_title": {
-    "message": "纠错等级"
-  },
-  "content_length_label_title": {
-    "message": "二维码内容长度，以字符数计"
+    "message": "二维码的容错等级，决定其对抗图像干扰的能力。"
   },
   "finder_style_label": {
-    "message": "定位标记样式:"
+    "message": "码眼样式："
   },
   "finder_style_label_title": {
-    "message": "为定位标记图案（三个角标记）选择样式"
+    "message": "为定位标记（三个角落里的框框）选择样式"
   },
   "module_style_label": {
-    "message": "模块样式:"
+    "message": "码点样式："
   },
   "module_style_label_title": {
-    "message": "为数据模块选择样式"
+    "message": "为二维码的数据内容点阵选择样式"
   },
   "image_size_label": {
     "message": "图像尺寸:"
   },
   "image_size_label_title": {
-    "message": "设置二维码的图像尺寸"
+    "message": "设置二维码图片的尺寸"
+  },
+  "content_length_label_title": {
+    "message": "二维码内容长度，以字数计"
   },
   "content_length_label": {
-    "message": "长度:"
+    "message": "内容长度："
   },
   "content_title": {
     "message": "二维码内容"
   },
   "content_placeholder": {
-    "message": "在此输入文字即可生成二维码"
+    "message": "此处可以输入文字，生成对应的二维码"
   },
   "context_menu_make_qr_code_for_link": {
     "message": "为该链接生成二维码"
   },
   "context_menu_make_qr_code_for_selected_text": {
-    "message": "生成 \"%s\" 的二维码"
+    "message": "生成“%s”的二维码"
   },
   "context_menu_scan_qr_code_in_image": {
-    "message": "扫描图片中的二维码"
+    "message": "扫描图中的二维码"
   },
   "context_menu_pick_region_to_scan": {
-    "message": "选择扫描区域..."
+    "message": "截屏选区扫码…"
   },
   "context_menu_scan_with_camera": {
-    "message": "用摄像头扫描"
+    "message": "从摄像头扫码"
   },
   "scan_region_picker_tips_scrollwheel": {
-    "message": "滚轮"
+    "message": "鼠标滑轮"
   },
   "scan_region_picker_tips_adjust_size": {
     "message": "调整大小"
@@ -130,14 +145,22 @@
     "message": "扫描"
   },
   "scan_region_picker_tips_esc": {
-    "message": "Esc",
-    "description": "[keep-original]"
+    "message": "脱出键"
   },
   "scan_region_picker_tips_exit": {
-    "message": "退出"
+    "message": "退出选区"
+  },
+  "scan_region_picker_tips_rescan": {
+    "message": "重新扫描"
+  },
+  "scan_region_picker_tips_open_url_mode_title": {
+    "message": "选择如何处理在扫描结果中的网址"
   },
   "copy_btn": {
     "message": "复制"
+  },
+  "copy_btn_title": {
+    "message": "复制到剪贴板"
   },
   "copy_btn_copied": {
     "message": "已复制"
@@ -146,66 +169,40 @@
     "message": "扫码失败：$MSG$",
     "placeholders": {
       "msg": {
-        "content": "$1"
+        "content": "$1",
+        "default": "发生未知错误"
       }
     }
   },
   "unable_to_decode": {
     "message": "无法读取二维码"
   },
+  "unable_to_load_image": {
+    "message": "无法加载图片"
+  },
+  "loading_image": {
+    "message": "正在加载图片…"
+  },
+  "image_scanner_failed_to_load_image": {
+    "message": "图片加载失败。其来源可能无法访问或受到限制。请尝试选择屏幕区域扫描。"
+  },
   "scan_instructions_html": {
-    "message": "右键单击任意图片并选择<br>“<img class=\"icon\" src=\"../icons/qrlite.svg\"></img> 扫描此图片中的二维码”"
+    "message": "右键单击任意图片并选择<br>“<img class=\"icon\" src=\"../icons/qrlite.svg\"></img> 扫描图中的二维码”"
   },
   "scan_from_clipboard_instructions_html": {
-    "message": "按 <kbd>Ctrl</kbd> + <kbd>V</kbd> <br> 或 <kbd>⌘</kbd> + <kbd>V</kbd> 来扫描剪贴板中的图片"
+    "message": "在此处按下 <kbd>Ctrl</kbd> + <kbd>V</kbd> 或 <kbd>⌘</kbd> + <kbd>V</kbd>（Mac）<br>来扫描剪贴板中的图片"
   },
   "pick_region_to_scan_btn": {
-    "message": "选择扫描区域"
+    "message": "截屏选区扫码"
   },
   "camera_scan_btn": {
-    "message": "用摄像头扫描"
+    "message": "从摄像头扫码"
   },
   "rescan_btn_label": {
     "message": "重新扫描"
   },
   "rescan_btn_title": {
     "message": "开始新的扫描"
-  },
-  "grant_camera_permission_name": {
-    "message": "使用摄像头"
-  },
-  "grant_permissions_window_title": {
-    "message": "授予权限"
-  },
-  "grant_camera_initial_instructions_firefox_html": {
-    "message": "您即将授予 QR Lite 使用摄像头的权限。<br><br>当浏览器询问您是否允许 QR Lite 使用摄像头时，请确保 <strong>\"对所有摄像头记住此设置\"</strong> 复选框已勾选，然后点击 <strong>\"允许\"</strong>。<br><br>点击下方按钮开始。"
-  },
-  "grant_camera_initial_instructions_chrome_html": {
-    "message": "您即将授予 QR Lite 使用摄像头的权限。<br><br>当浏览器询问您是否允许 QR Lite 使用摄像头时，请选择 <strong>\"允许在访问网站期间\"</strong>。<br><br>点击下方按钮开始。"
-  },
-  "grant_camera_blocked_instructions_firefox_html": {
-    "message": "QR Lite 的摄像头权限似乎已经被设定为<strong>阻止</strong>了。<br><br>如要修改该设定，请点击地址栏左边的 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 图标，然后将“使用摄像头”一栏的“已阻止”状态<strong>移除</strong>。<br><br>完成该操作后，请刷新本页面。"
-  },
-  "grant_camera_blocked_instructions_chrome_html": {
-    "message": "QR Lite 的摄像头权限似乎已经被设定为<strong>阻止</strong>了。<br><br>如要修改该设定，请点击地址栏上的 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 图标，并选择 <strong>始终允许 QR Lite - 二维码生成器和扫描器 访问您的摄像头</strong>。<br><br>完成该操作后，请刷新本页面。"
-  },
-  "grant_camera_granted_instructions_html": {
-    "message": "QR Lite 已经成功获得摄像头权限。<br><br>您现在可以关闭本页面了。"
-  },
-  "grant_page_refresh_btn": {
-    "message": "刷新"
-  },
-  "grant_page_dont_see_icon_btn_html": {
-    "message": "我找不到 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 图标！"
-  },
-  "grant_page_dont_see_icon_instructions_html": {
-    "message": "有些浏览器会在几秒后隐藏该图标。请点击下面的按钮将其显示出来。"
-  },
-  "grant_page_dont_see_icon_instructions_reveal_icon_btn_label": {
-    "message": "显示图标"
-  },
-  "grant_page_close_btn": {
-    "message": "关闭"
   },
   "grant_permissions_instructions_html": {
     "message": "此功能需要以下附加权限。<br><br><strong>$PERMISSION$</strong><br>",
@@ -218,92 +215,119 @@
   "grant_permissions_btn": {
     "message": "授予权限"
   },
-  "or": {
-    "message": "或者"
+  "grant_camera_permission_name": {
+    "message": "读取摄像头"
   },
-  "scanning": {
-    "message": "扫描中..."
-  },
-  "unable_to_decode_qr_code": {
-    "message": "二维码解码失败"
-  },
-  "browser_action_command_description": {
-    "message": "显示弹出框"
-  },
-  "select_region_to_scan_command_description": {
-    "message": "选择扫描区域"
-  },
-  "scan_with_camera_command_description": {
-    "message": "用摄像头扫描"
-  },
-  "picker_close_btn_title": {
-    "message": "关闭"
-  },
-  "disable_history_btn_title": {
-    "message": "暂停历史记录"
-  },
-  "disable_history_btn_label": {
-    "message": "暂停"
-  },
-  "enable_history_btn_title": {
-    "message": "恢复历史记录"
-  },
-  "enable_history_btn_label": {
-    "message": "恢复"
-  },
-  "remove_history_btn_title": {
-    "message": "从历史记录中删除此条目"
-  },
-  "select_region_to_scan_open_command_description": {
-    "message": "选择区域进行扫描并打开 URL"
-  },
-  "select_region_to_scan_open_new_bg_tab_command_description": {
-    "message": "选择区域进行扫描并在新的后台标签页中打开 URL"
-  },
-  "select_region_to_scan_open_new_fg_tab_command_description": {
-    "message": "选择区域进行扫描并在新的前台标签页中打开 URL"
-  },
-  "picker_url_mode_auto_open_no": {
-    "message": "不自动打开 URL"
-  },
-  "picker_url_mode_auto_open_in_current_tab": {
-    "message": "在当前标签页中自动打开 URL"
-  },
-  "picker_url_mode_auto_open_in_bg_tab": {
-    "message": "在新的后台标签页中自动打开 URL"
-  },
-  "picker_url_mode_auto_open_in_fg_tab": {
-    "message": "在新的前台标签页中自动打开 URL"
-  },
-  "copy_btn_title": {
-    "message": "复制到剪贴板"
+  "grant_permissions_window_title": {
+    "message": "授予权限"
   },
   "grant_permissions_error_details_summary": {
     "message": "错误详情"
   },
+  "grant_camera_initial_instructions_firefox_html": {
+    "message": "您即将授予 QR Lite 使用摄像头的权限。<br><br>当浏览器询问您是否允许 QR Lite 使用摄像头时，请确认勾选 <strong>“对所有摄像头记住此设置”</strong> 复选框，然后点击 <strong>“允许”</strong>。<br><br>点击下方按钮开始。"
+  },
+  "grant_camera_initial_instructions_chrome_html": {
+    "message": "您即将授予 QR Lite 使用摄像头的权限。<br><br>当浏览器询问您是否允许 QR Lite 使用摄像头时，请选择 <strong>“允许在此页访问”</strong>。<br><br>点击下方按钮开始。"
+  },
+  "grant_camera_blocked_instructions_firefox_html": {
+    "message": "您似乎已经<strong>阻止</strong>了 QR Lite 访问您的摄像头。<br><br>如要解除该状态，请点击地址栏左侧的 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 图标，然后将“使用摄像头”一栏的“已阻止”状态<strong>移除</strong>。<br><br>完成该操作后，请刷新本页面。"
+  },
+  "grant_camera_blocked_instructions_chrome_html": {
+    "message": "您似乎已经<strong>阻止</strong>了 QR Lite 访问您的摄像头。<br><br>如要修改该设定，请点击地址栏上的 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 图标，并选择 <strong>始终允许 QR Lite - 离线二维码读写器 访问您的摄像头</strong>。<br><br>完成该操作后，请刷新本页面。"
+  },
   "grant_camera_unusable_instructions_html": {
-    "message": "摄像头似乎无法访问。是否有其他程序正在使用摄像头？<br><br>请关闭可能正在使用摄像头的其他程序，然后刷新此页面。"
+    "message": "当前无法访问您的摄像头。是否有其他程序正在使用摄像头？<br><br>请关闭可能正在使用摄像头的其他应用，然后刷新此页面。"
   },
   "grant_camera_unknow_error_instructions_html": {
     "message": "尝试获取摄像头访问权限时发生未知错误。<br><br>请刷新此页面并重试。"
   },
+  "grant_camera_granted_instructions_html": {
+    "message": "QR Lite 已经成功取得摄像头访问权限。<br><br>您现在可以关闭本页面了。"
+  },
+  "grant_page_refresh_btn": {
+    "message": "刷新"
+  },
+  "grant_page_dont_see_icon_btn_html": {
+    "message": "找不到 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 图标吗？"
+  },
+  "grant_page_dont_see_icon_instructions_html": {
+    "message": "有些浏览器会在几秒后隐藏该图标。请点击下面的按钮以将其显示出来。"
+  },
+  "grant_page_dont_see_icon_instructions_reveal_icon_btn_label": {
+    "message": "显示 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 图标"
+  },
+  "grant_page_close_btn": {
+    "message": "关闭"
+  },
+  "or": {
+    "message": "或者"
+  },
+  "scanning": {
+    "message": "正在扫描中…"
+  },
+  "unable_to_decode_qr_code": {
+    "message": "无法解析二维码"
+  },
   "unable_to_access_camera": {
     "message": "无法访问摄像头。是否有其他程序正在使用摄像头？"
+  },
+  "unable_to_access_camera_unknown_error": {
+    "message": "无法访问摄像头。发生了一个意外错误。"
+  },
+  "browser_action_command_description": {
+    "message": "打开拓展弹窗"
+  },
+  "select_region_to_scan_command_description": {
+    "message": "截屏选区扫码"
+  },
+  "scan_with_camera_command_description": {
+    "message": "从摄像头扫码"
+  },
+  "picker_close_btn_title": {
+    "message": "关闭"
+  },
+  "select_region_to_scan_open_command_description": {
+    "message": "截屏选区扫码并打开其中的链接"
+  },
+  "select_region_to_scan_open_new_bg_tab_command_description": {
+    "message": "截屏选区扫码后在新标签页打开其中的链接"
+  },
+  "select_region_to_scan_open_new_fg_tab_command_description": {
+    "message": "截屏选区扫码后在新标签页打开其中的链接并切换至该页"
+  },
+  "picker_url_mode_auto_open_no": {
+    "message": "不自动打开扫描结果中的链接"
+  },
+  "picker_url_mode_auto_open_in_current_tab": {
+    "message": "在当前页打开结果中的链接"
+  },
+  "picker_url_mode_auto_open_in_bg_tab": {
+    "message": "新建标签页开启结果中的链接"
+  },
+  "picker_url_mode_auto_open_in_fg_tab": {
+    "message": "新建标签页开启结果中的链接并并切换至该页"
   },
   "settings_window_title": {
     "message": "QR Lite 设置"
   },
   "settings_scan_success_sound_enabled_label": {
-    "message": "扫描成功时播放声音"
+    "message": "扫描提示音"
   },
   "settings_scan_success_sound_enabled_explainer": {
-    "message": "成功扫描到二维码时播放提示音。"
+    "message": "成功扫描二维码时播放“啵”的提示音。"
+  },
+  "settings_picker_pause_videos_onload_enabled_label": {
+    "message": "在“截屏选区扫码”期间暂停所有视频"
+  },
+  "settings_picker_pause_videos_onload_enabled_explainer": {
+    "message": "在选择扫描区域时暂停正在播放的视频，以免错过任何二维码。"
   },
   "settings_white_on_black_qr_ccode_in_dark_mode_label": {
-    "message": "在深色模式下生成黑色背景上的白色二维码"
+    "message": "深色模式颜色反转"
   },
   "settings_white_on_black_qr_ccode_in_dark_mode_explainer": {
-    "message": "在深色模式下，生成深色背景上的浅色前景色的二维码。某些扫描仪可能难以扫描此类二维码。您通过“保存”和“复制”按钮保存或复制的二维码将始终具有白色背景和黑色前景色。"
+    "message": "在深色模式下，生成深色背景上的白前景色的二维码。某些扫描软件可能难以解析此类二维码。即使您开启此功能，您通过“保存”和“复制”按钮保存或复制的二维码将始终是在白色背景下的黑色二维码。"
   },
   "settings_scanner_legend": {
     "message": "二维码扫描"
@@ -316,29 +340,5 @@
   },
   "settings_config_keyboard_shortcuts_btn_label": {
     "message": "配置键盘快捷键"
-  },
-  "unable_to_access_camera_unknown_error": {
-    "message": "无法访问摄像头。发生了一个意外错误。"
-  },
-  "scan_region_picker_tips_rescan": {
-    "message": "重新扫描"
-  },
-  "scan_region_picker_tips_open_url_mode_title": {
-    "message": "选择如何在扫描结果中处理网址"
-  },
-  "unable_to_load_image": {
-    "message": "无法加载图片"
-  },
-  "settings_picker_pause_videos_onload_enabled_label": {
-    "message": "在“选择要扫描的区域”期间暂停所有视频"
-  },
-  "settings_picker_pause_videos_onload_enabled_explainer": {
-    "message": "在选择扫描区域时暂停视频，以免您错过任何二维码。"
-  },
-  "image_scanner_failed_to_load_image": {
-    "message": "图片加载失败。其来源可能无法访问或受到限制。请尝试扫描屏幕区域。"
-  },
-  "loading_image": {
-    "message": "正在加载图片..."
   }
 }

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -151,7 +151,7 @@
     "message": "退出選取範圍"
   },
   "scan_region_picker_tips_rescan": {
-    "message": "重新掃描"
+    "message": "重新選取"
   },
   "scan_region_picker_tips_open_url_mode_title": {
     "message": "選擇如何處理掃描結果中的網址"
@@ -199,10 +199,10 @@
     "message": "使用攝影機掃描"
   },
   "rescan_btn_label": {
-    "message": "重新掃描"
+    "message": "重新選取"
   },
   "rescan_btn_title": {
-    "message": "開始新的掃描"
+    "message": "重新選取一塊新的螢幕區域以開始新的掃描"
   },
   "grant_permissions_instructions_html": {
     "message": "此功能需要以下額外權限。<br><br><strong>$PERMISSION$</strong><br>",

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -7,19 +7,19 @@
     "description": "[keep-original]"
   },
   "extension_description": {
-    "message": "離線產生或掃描二維碼。"
+    "message": "離線產生或掃描 QR Code。"
   },
   "save_image_btn": {
     "message": "儲存"
   },
   "save_image_btn_title": {
-    "message": "儲存這張二維碼圖片"
+    "message": "儲存這張 QR Code"
   },
   "copy_image_btn": {
     "message": "複製"
   },
   "copy_image_btn_title": {
-    "message": "複製這張二維碼圖片到剪貼簿"
+    "message": "將這張 QR Code 複製到剪貼簿"
   },
   "copy_image_ok": {
     "message": "已複製！"
@@ -45,80 +45,95 @@
   "clear_history_btn_title": {
     "message": "清除歷史記錄"
   },
+  "disable_history_btn_title": {
+    "message": "停止記錄掃描或產生的內容"
+  },
+  "disable_history_btn_label": {
+    "message": "停用"
+  },
+  "enable_history_btn_title": {
+    "message": "重新啟用歷史記錄功能"
+  },
+  "enable_history_btn_label": {
+    "message": "啟用"
+  },
+  "remove_history_btn_title": {
+    "message": "從歷史記錄中刪除此項目"
+  },
   "github_link_title": {
-    "message": "造訪 QR Lite 在 Github 上的專案主頁"
+    "message": "造訪 QR Lite 在 GitHub 上的專案頁"
   },
   "toggle_generator_options_btn_label": {
-    "message": "選項"
+    "message": "產生選項"
   },
   "toggle_generator_options_btn_title": {
-    "message": "顯示/隱藏 QR 碼產生器選項"
+    "message": "顯示／隱藏產生器選項"
   },
   "error_correction_level_btn_low_title": {
-    "message": "低，可以恢復 7% 左右的資料"
+    "message": "低，可修正 7% 的錯誤字碼"
   },
   "error_correction_level_btn_medium_title": {
-    "message": "中，可以恢復 15% 左右的資料"
+    "message": "中，可修正 15% 的錯誤字碼"
   },
   "error_correction_level_btn_quartile_title": {
-    "message": "四分，可以恢復 25% 左右的資料"
+    "message": "良，可修正 25% 的錯誤字碼"
   },
   "error_correction_level_btn_high_title": {
-    "message": "高，可以恢復 30% 左右的資料"
+    "message": "高，可修正 30% 的錯誤字碼"
   },
   "error_correction_level_label": {
-    "message": "糾錯:"
+    "message": "容錯等級："
   },
   "error_correction_level_label_title": {
-    "message": "糾錯級別"
-  },
-  "content_length_label_title": {
-    "message": "二維碼內容長度，以字元數計"
+    "message": "QR Code 的容錯等級，決定其對抗圖像干擾的能力。"
   },
   "finder_style_label": {
-    "message": "定位標記樣式:"
+    "message": "定位點樣式："
   },
   "finder_style_label_title": {
-    "message": "為定位標記圖案（三個角標記）選擇樣式"
+    "message": "為定位標記（位於三個角落的方框）選擇樣式"
   },
   "module_style_label": {
-    "message": "模組樣式:"
+    "message": "資料點樣式："
   },
   "module_style_label_title": {
-    "message": "為資料模組選擇樣式"
+    "message": "為 QR Code 的資料內容點陣選擇樣式"
   },
   "image_size_label": {
-    "message": "圖片尺寸:"
+    "message": "圖片尺寸："
   },
   "image_size_label_title": {
-    "message": "設定二維碼的圖片尺寸"
+    "message": "設定 QR Code 圖片的尺寸"
+  },
+  "content_length_label_title": {
+    "message": "QR Code 內容長度，以字數計算"
   },
   "content_length_label": {
-    "message": "長度:"
+    "message": "內容長度："
   },
   "content_title": {
-    "message": "二維碼內容"
+    "message": "QR Code 內容"
   },
   "content_placeholder": {
-    "message": "在此輸入文字即可產生二維碼"
+    "message": "此處可輸入文字，以產生對應的 QR Code"
   },
   "context_menu_make_qr_code_for_link": {
-    "message": "為該連結產生二維碼"
+    "message": "為此連結產生 QR Code"
   },
   "context_menu_make_qr_code_for_selected_text": {
-    "message": "產生 \"%s\" 的二維碼"
+    "message": "產生「%s」的 QR Code"
   },
   "context_menu_scan_qr_code_in_image": {
-    "message": "掃描圖片中的二維碼"
+    "message": "掃描圖片中的 QR Code"
   },
   "context_menu_pick_region_to_scan": {
-    "message": "選擇掃描區域..."
+    "message": "擷取螢幕區域掃描…"
   },
   "context_menu_scan_with_camera": {
-    "message": "用攝影機掃描"
+    "message": "使用攝影機掃描"
   },
   "scan_region_picker_tips_scrollwheel": {
-    "message": "滾輪"
+    "message": "滑鼠滾輪"
   },
   "scan_region_picker_tips_adjust_size": {
     "message": "調整大小"
@@ -130,40 +145,58 @@
     "message": "掃描"
   },
   "scan_region_picker_tips_esc": {
-    "message": "Esc",
-    "description": "[keep-original]"
+    "message": "Esc 鍵"
   },
   "scan_region_picker_tips_exit": {
-    "message": "退出"
+    "message": "退出選取範圍"
+  },
+  "scan_region_picker_tips_rescan": {
+    "message": "重新掃描"
+  },
+  "scan_region_picker_tips_open_url_mode_title": {
+    "message": "選擇如何處理掃描結果中的網址"
   },
   "copy_btn": {
     "message": "複製"
+  },
+  "copy_btn_title": {
+    "message": "複製到剪貼簿"
   },
   "copy_btn_copied": {
     "message": "已複製"
   },
   "decoding_failed": {
-    "message": "掃碼失敗：$MSG$",
+    "message": "掃描失敗：$MSG$",
     "placeholders": {
       "msg": {
-        "content": "$1"
+        "content": "$1",
+        "default": "發生未知錯誤"
       }
     }
   },
   "unable_to_decode": {
-    "message": "無法讀取二維碼"
+    "message": "無法讀取 QR Code"
+  },
+  "unable_to_load_image": {
+    "message": "無法載入圖片"
+  },
+  "loading_image": {
+    "message": "正在載入圖片…"
+  },
+  "image_scanner_failed_to_load_image": {
+    "message": "圖片載入失敗。其來源可能無法存取或受到限制。請嘗試擷取螢幕區域進行掃描。"
   },
   "scan_instructions_html": {
-    "message": "右鍵單擊任意圖片並選擇<br>「<img class=\"icon\" src=\"../icons/qrlite.svg\"></img> 掃描圖片中的二維碼」"
+    "message": "在任何圖片上按右鍵並選擇<br>「<img class=\"icon\" src=\"../icons/qrlite.svg\"></img> 掃描圖片中的 QR Code」"
   },
   "scan_from_clipboard_instructions_html": {
-    "message": "按 <kbd>Ctrl</kbd> + <kbd>V</kbd> <br> 或 <kbd>⌘</kbd> + <kbd>V</kbd> 來掃描剪貼簿中的圖片"
+    "message": "在此處按下 <kbd>Ctrl</kbd> + <kbd>V</kbd> 或 <kbd>⌘</kbd> + <kbd>V</kbd>（Mac）<br>來掃描剪貼簿中的圖片"
   },
   "pick_region_to_scan_btn": {
-    "message": "選擇掃描區域"
+    "message": "擷取螢幕區域掃描"
   },
   "camera_scan_btn": {
-    "message": "用攝影機掃描"
+    "message": "使用攝影機掃描"
   },
   "rescan_btn_label": {
     "message": "重新掃描"
@@ -171,29 +204,8 @@
   "rescan_btn_title": {
     "message": "開始新的掃描"
   },
-  "grant_camera_permission_name": {
-    "message": "使用攝影機"
-  },
-  "grant_permissions_window_title": {
-    "message": "授予權限"
-  },
-  "grant_camera_initial_instructions_firefox_html": {
-    "message": "您即將授予 QR Lite 使用相機的權限。<br><br>當瀏覽器詢問您是否允許 QR Lite 使用相機時，請確保 <strong>\"對所有相機記住此設定\"</strong> 核取方塊已勾選，然後點擊 <strong>\"允許\"</strong>。<br><br>點擊下方按鈕開始。"
-  },
-  "grant_camera_initial_instructions_chrome_html": {
-    "message": "您即將授予 QR Lite 使用相機的權限。<br><br>當瀏覽器詢問您是否允許 QR Lite 使用相機時，請選擇 <strong>\"允許在造訪網站期間\"</strong>。<br><br>點擊下方按鈕開始。"
-  },
-  "grant_camera_blocked_instructions_firefox_html": {
-    "message": "QR Lite 的攝影機權限似乎已經被設定爲<strong>封鎖</strong>了。<br><br>若要改變此設定，請點擊網址列左邊的 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 圖示，然後將「使用攝影機」旁邊的「已封鎖」狀態<strong>移除</strong>。<br><br>完成此操作後，請重新載入本頁。"
-  },
-  "grant_camera_blocked_instructions_chrome_html": {
-    "message": "QR Lite 的攝影機權限似乎已經被設定爲<strong>封鎖</strong>了。<br><br>若要改變此設定，請點擊網址列上的 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 圖示，並選擇 <strong>一律允許 QR Lite - QR Code 產生器與掃描器 存取您的攝影機</strong>。<br><br>完成此操作後，請重新載入本頁。"
-  },
-  "grant_camera_granted_instructions_html": {
-    "message": "QR Lite 已经成功获得攝影機權限。<br><br>現在您可以關閉本頁了。"
-  },
   "grant_permissions_instructions_html": {
-    "message": "此功能需要以下附加權限<br><br><strong>$PERMISSION$</strong><br>",
+    "message": "此功能需要以下額外權限。<br><br><strong>$PERMISSION$</strong><br>",
     "placeholders": {
       "permission": {
         "content": "$1"
@@ -203,142 +215,130 @@
   "grant_permissions_btn": {
     "message": "授予權限"
   },
+  "grant_camera_permission_name": {
+    "message": "存取攝影機"
+  },
+  "grant_permissions_window_title": {
+    "message": "授予權限"
+  },
+  "grant_permissions_error_details_summary": {
+    "message": "錯誤詳細資訊"
+  },
+  "grant_camera_initial_instructions_firefox_html": {
+    "message": "您即將授予 QR Lite 使用攝影機的權限。<br><br>當瀏覽器詢問您是否允許 QR Lite 使用攝影機時，請確認勾選<strong>「對所有攝影機記住此設定」</strong>核取方塊，然後點擊<strong>「允許」</strong>。<br><br>點擊下方按鈕開始。"
+  },
+  "grant_camera_initial_instructions_chrome_html": {
+    "message": "您即將授予 QR Lite 使用攝影機的權限。<br><br>當瀏覽器詢問您是否允許 QR Lite 使用攝影機時，請選擇<strong>「允許在此網頁存取」</strong>。<br><br>點擊下方按鈕開始。"
+  },
+  "grant_camera_blocked_instructions_firefox_html": {
+    "message": "您似乎已經<strong>封鎖</strong>了 QR Lite 存取您的攝影機。<br><br>若要解除此狀態，請點擊網址列左側的 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 圖示，然後將「使用攝影機」欄位的「已封鎖」狀態<strong>移除</strong>。<br><br>完成該操作後，請重新整理本頁面。"
+  },
+  "grant_camera_blocked_instructions_chrome_html": {
+    "message": "您似乎已經<strong>封鎖</strong>了 QR Lite 存取您的攝影機。<br><br>若要修改此設定，請點擊網址列上的 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 圖示，並選擇<strong>一律允許 QR Lite - QR Code 產生器與掃描器存取您的攝影機</strong>。<br><br>完成該操作後，請重新整理本頁面。"
+  },
+  "grant_camera_unusable_instructions_html": {
+    "message": "目前無法存取您的攝影機。是否有其他程式正在使用攝影機？<br><br>請關閉可能正在使用攝影機的其他应用程式，然後重新整理此頁面。"
+  },
+  "grant_camera_unknow_error_instructions_html": {
+    "message": "嘗試取得攝影機存取權限時發生未知錯誤。<br><br>請重新整理此頁面並重試。"
+  },
+  "grant_camera_granted_instructions_html": {
+    "message": "QR Lite 已成功取得攝影機存取權限。<br><br>您現在可以關閉本頁面了。"
+  },
   "grant_page_refresh_btn": {
-    "message": "重新載入"
+    "message": "重新整理"
   },
   "grant_page_dont_see_icon_btn_html": {
-    "message": "我找不到 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 圖示！"
+    "message": "我找不到 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 圖示？"
   },
   "grant_page_dont_see_icon_instructions_html": {
-    "message": "有些瀏覽器會在幾秒後隱藏圖示。請點擊下方按鈕將其顯示出來。"
+    "message": "部分瀏覽器會在幾秒後隱藏該圖示。請點擊下方按鈕將其顯示出來。"
   },
   "grant_page_dont_see_icon_instructions_reveal_icon_btn_label": {
-    "message": "顯示圖示"
+    "message": "顯示 <img class=\"icon icon-invert\" src=\"../icons/no-camera.svg\"></img> 圖示"
   },
   "grant_page_close_btn": {
     "message": "關閉"
   },
   "or": {
-    "message": "或者"
+    "message": "或"
   },
   "scanning": {
-    "message": "掃描中..."
+    "message": "正在掃描…"
   },
   "unable_to_decode_qr_code": {
-    "message": "二維碼解碼失敗"
+    "message": "無法解析 QR Code"
+  },
+  "unable_to_access_camera": {
+    "message": "無法存取攝影機。是否有其他程式正在使用攝影機？"
+  },
+  "unable_to_access_camera_unknown_error": {
+    "message": "無法存取攝影機。發生了意外錯誤。"
   },
   "browser_action_command_description": {
-    "message": "展開彈出視窗"
+    "message": "打開擴充功能彈出視窗"
   },
   "select_region_to_scan_command_description": {
-    "message": "選擇掃描區域"
+    "message": "擷取螢幕區域掃描"
   },
   "scan_with_camera_command_description": {
-    "message": "用攝影機掃描"
+    "message": "使用攝影機掃描"
   },
   "picker_close_btn_title": {
     "message": "關閉"
   },
-  "disable_history_btn_title": {
-    "message": "暫停歷史記錄"
-  },
-  "disable_history_btn_label": {
-    "message": "暫停"
-  },
-  "enable_history_btn_title": {
-    "message": "恢復歷史記錄"
-  },
-  "enable_history_btn_label": {
-    "message": "恢復"
-  },
-  "remove_history_btn_title": {
-    "message": "從歷史記錄中刪除此條目"
-  },
   "select_region_to_scan_open_command_description": {
-    "message": "選擇區域進行掃描並開啟 URL"
+    "message": "擷取螢幕區域掃描並開啟其中的連結"
   },
   "select_region_to_scan_open_new_bg_tab_command_description": {
-    "message": "選擇區域進行掃描並在新的背景分頁中開啟 URL"
+    "message": "擷取螢幕區域掃描後在新分頁開啟其中的連結"
   },
   "select_region_to_scan_open_new_fg_tab_command_description": {
-    "message": "選擇區域進行掃描並在新的前景分頁中開啟 URL"
+    "message": "擷取螢幕區域掃描後在新分頁開啟其中的連結並切換至該分頁"
   },
   "picker_url_mode_auto_open_no": {
-    "message": "不要自動開啟 URL"
+    "message": "不自動開啟掃描結果中的連結"
   },
   "picker_url_mode_auto_open_in_current_tab": {
-    "message": "在目前分頁中自動開啟 URL"
+    "message": "在目前分頁中開啟結果中的連結"
   },
   "picker_url_mode_auto_open_in_bg_tab": {
-    "message": "在新的背景分頁中自動開啟 URL"
+    "message": "在新分頁開啟結果中的連結"
   },
   "picker_url_mode_auto_open_in_fg_tab": {
-    "message": "在新的前景分頁中自動開啟 URL"
-  },
-  "copy_btn_title": {
-    "message": "複製到剪貼簿"
-  },
-  "grant_permissions_error_details_summary": {
-    "message": "錯誤詳情"
-  },
-  "grant_camera_unusable_instructions_html": {
-    "message": "攝影機似乎無法存取。是否有其他程式正在使用攝影機？<br><br>請關閉可能正在使用攝影機的其他程式，然後重新整理此頁面。"
-  },
-  "grant_camera_unknow_error_instructions_html": {
-    "message": "嘗試取得攝影機存取權時發生不明錯誤。<br><br>請重新整理此頁面並重試。"
-  },
-  "unable_to_access_camera": {
-    "message": "無法存取攝影機。是否有其他程式正在使用攝影機？"
+    "message": "在新分頁開啟結果中的連結並切換至該分頁"
   },
   "settings_window_title": {
     "message": "QR Lite 設定"
   },
   "settings_scan_success_sound_enabled_label": {
-    "message": "掃描成功時播放聲音"
+    "message": "掃描提示音"
   },
   "settings_scan_success_sound_enabled_explainer": {
-    "message": "成功掃描到 QR 碼時播放提示音。"
+    "message": "成功掃描 QR Code 時播放「啵」的提示音。"
+  },
+  "settings_picker_pause_videos_onload_enabled_label": {
+    "message": "在「擷取螢幕區域掃描」期間暫停所有影片"
+  },
+  "settings_picker_pause_videos_onload_enabled_explainer": {
+    "message": "在選擇掃描區域時暫停正在播放的影片，以免錯過任何 QR Code。"
   },
   "settings_white_on_black_qr_ccode_in_dark_mode_label": {
-    "message": "在深色模式下產生黑色背景上的白色 QR 碼"
+    "message": "深色模式顏色反轉"
   },
   "settings_white_on_black_qr_ccode_in_dark_mode_explainer": {
-    "message": "在深色模式下，產生深色背景上的淺色前景色的 QR 碼。某些掃描器可能難以掃描此類 QR 碼。您透過「儲存」和「複製」按鈕儲存或複製的 QR 碼將始終具有白色背景和黑色前景色。"
+    "message": "在深色模式下，產生深色背景搭配白色前景的 QR Code。部分掃描軟體可能難以解析此類 QR Code。即使您開啟此功能，透過「儲存」和「複製」按鈕儲存或複製的 QR Code 仍會維持白底黑色的樣式。"
   },
   "settings_scanner_legend": {
-    "message": "QR 碼掃描"
+    "message": "QR Code 掃描"
   },
   "settings_generator_legend": {
-    "message": "QR 碼產生"
+    "message": "QR Code 產生"
   },
   "tab_settings_title": {
     "message": "變更 QR Lite 的設定"
   },
   "settings_config_keyboard_shortcuts_btn_label": {
     "message": "設定鍵盤快速鍵"
-  },
-  "unable_to_access_camera_unknown_error": {
-    "message": "無法存取相機。發生了非預期的錯誤。"
-  },
-  "scan_region_picker_tips_rescan": {
-    "message": "重新掃描"
-  },
-  "scan_region_picker_tips_open_url_mode_title": {
-    "message": "選擇如何在掃描結果中處理網址"
-  },
-  "unable_to_load_image": {
-    "message": "無法載入圖片"
-  },
-  "settings_picker_pause_videos_onload_enabled_label": {
-    "message": "在「選取要掃描的區域」期間暫停所有影片"
-  },
-  "settings_picker_pause_videos_onload_enabled_explainer": {
-    "message": "在您選取掃描區域時暫停影片，以免您錯過任何 QR 圖碼。"
-  },
-  "image_scanner_failed_to_load_image": {
-    "message": "圖片載入失敗。其來源可能無法存取或受到限制。請嘗試掃描螢幕區域。"
-  },
-  "loading_image": {
-    "message": "正在載入圖片..."
   }
 }


### PR DESCRIPTION
1. update the translation of `zh-CN` for Simplified Chinese (China Mainland) and `zh-TW` for Traditional Chinese (Taiwan Province).
2. Reorder the `zh-CN` and `zh-TW` locale json file to make it same order as `en`

---

1. 更新了大陆简体和台湾繁体的中文翻译文本，使之更加自然。
2. 重新给上述两个文本的 `JSON` 本地化文件里的键排序，使之与英文原文能够对照。